### PR TITLE
895ac

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -220,7 +220,7 @@ static void settings_init(void) {
     settings.backlog = 1024;
     settings.binding_protocol = negotiating_prot;
     settings.item_size_max = 1024 * 1024; /* The famous 1MB upper limit. */
-    settings.maxconns_fast = false;
+    settings.maxconns_fast = true;
     settings.hashpower_init = 0;
     settings.slab_reassign = false;
     settings.slab_automove = false;

--- a/thread.c
+++ b/thread.c
@@ -736,6 +736,9 @@ void thread_init(int nthreads, struct event_base *main_base) {
     dispatcher_thread.base = main_base;
     dispatcher_thread.thread_id = pthread_self();
     
+    /* 3 for console, 3 for libevent base in master thread */ 
+    stats.reserved_fds = 3 + 3;
+
     for (i = 0; i < nthreads; i++) {
         int fds[2];
         if (pipe(fds)) {


### PR DESCRIPTION
fix number of reserved fds, and make maxconns_fast as default.
